### PR TITLE
Fetch Debian/Ubuntu mirrors + refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- added Debian/Ubuntu support
+
 # 0.9.0 (2022-01-06)
 
 - added initial EndeavourOS support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambassador"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61874b33258f18ca7923047c12887078ccfe95c2811b03c1a09e309c19b7e50b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +831,7 @@ dependencies = [
 name = "rate_mirrors"
 version = "0.9.0"
 dependencies = [
+ "ambassador",
  "byte-unit",
  "chrono",
  "futures",
@@ -834,6 +846,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "thiserror",
  "tokio",
  "url",
 ]
@@ -1092,6 +1105,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1282,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +199,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9c1ce3fa9336301af935ab852c437817d14cd33690446569392e65170aac3b"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,13 +304,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -329,6 +365,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aafcf38a1a36118242d29b92e1b08ef84e67e4a5ed06e0a80be20e6a32bfed6b"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -502,6 +552,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f015da43bcd8d4f144559a3423f4591d69b8ce0652c905374da7205df336ae2b"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +640,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
@@ -690,6 +778,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +858,12 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-error"
@@ -789,14 +921,38 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -806,7 +962,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -815,7 +980,16 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.3",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -824,7 +998,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.2",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -840,9 +1023,10 @@ dependencies = [
  "linkify",
  "nix",
  "openssl",
- "rand",
+ "rand 0.8.3",
  "regex",
  "reqwest",
+ "select",
  "serde",
  "serde_json",
  "structopt",
@@ -967,6 +1151,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "select"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee061f90afcc8678bef7a78d0d121683f0ba753f740ff7005f833ec445876b7"
+dependencies = [
+ "bit-set",
+ "html5ever",
+ "markup5ever_rcdom",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1239,32 @@ checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923f0f39b6267d37d23ce71ae7235602134b250ace715dd2c90421998ddac0c6"
+dependencies = [
+ "lazy_static",
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1089,10 +1316,21 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.8.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ef557cb397a4f0a5a3a628f06515f78563f2209e64d47055d9dc6052bf5e33"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -1286,6 +1524,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1562,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -1432,4 +1682,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9234163818fd8e2418fcde330655e757900d4236acd8cc70fef345ef91f6d865"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ nix = "0.20"
 regex = "1.5"
 url = { version = "2.2", features = ["serde"] }
 linkify = "0.7.0"
+select = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,19 +7,21 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json"] }
-futures = "0.3"                 # An implementation of futures and streams featuring zero allocations, composability, and itera…
-tokio = { version = "1.0", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"                     # A JSON serialization file format
-structopt = "0.3"               # Parse command line argument by defining a struct.
-byte-unit = "4.0.9"     # A library for interaction with units of bytes
-lazy_static = "1.4.0"            # A macro for declaring lazily evaluated statics in Rust.
-itertools = "0.10.0"         # Extra iterator adaptors, iterator methods, free functions, and macros.
-rand = "0.8.2"
 openssl = { version = "0.10", features = ["vendored"] }
+reqwest = { version = "0.11", features = ["json", "blocking"] }
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.0", features = ["full"] }
+futures = "0.3"         # An implementation of futures and streams featuring zero allocations, composability, and itera…
+serde_json = "1.0"      # A JSON serialization file format
+structopt = "0.3"       # Parse command line argument by defining a struct.
+byte-unit = "4.0.9"     # A library for interaction with units of bytes
+lazy_static = "1.4.0"   # A macro for declaring lazily evaluated statics in Rust.
+itertools = "0.10.0"    # Extra iterator adaptors, iterator methods, free functions, and macros.
+ambassador = "0.2.1"    # Deriving the delegating trait implementation via procedural macros.
+thiserror = "1"
+rand = "0.8.2"
 chrono = "0.4"
 nix = "0.20"
 regex = "1.5"
-url = "2.2"
+url = { version = "2.2", features = ["serde"] }
 linkify = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
-reqwest = { version = "0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 futures = "0.3"         # An implementation of futures and streams featuring zero allocations, composability, and itera…

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This is a tool, which tests mirror speed for:
 - Artix Linux
 - CachyOS
 - EndeavourOS
+- Debian
+- Ubuntu
 - any http/https mirrors via stdin.
 
 It uses info about submarine cables and internet exchanges to jump between
@@ -42,7 +44,7 @@ Each subcommand has its own options, so run `rate-mirrors arch --help` to see
 arch specific options, which should go after arch sub-command.
 
 
-1. `rate-mirrors arch` -- fetches Arch Linux mirrors, skips outdated/syncing
+1. `rate-mirrors arch` — fetches Arch Linux mirrors, skips outdated/syncing
    ones and tests them.
 
    To backup `/etc/pacman.d/mirrorlist` file and update it with the rated mirrors run the command below:
@@ -57,22 +59,26 @@ arch specific options, which should go after arch sub-command.
 
    Or just put the output to `/etc/pacman.d/mirrorlist` yourself.
 
-2. `rate-mirrors manjaro` -- fetches Manjaro mirrors, skips outdated ones and tests them
+2. `rate-mirrors manjaro` — fetches Manjaro mirrors, skips outdated ones and tests them
 
-3. `rate-mirrors rebornos` -- fetches RebornOS mirrors and tests them
+3. `rate-mirrors rebornos` — fetches RebornOS mirrors and tests them
 
-4. `rate-mirrors artix` -- fetches Artix Linux mirrors and tests them
+4. `rate-mirrors artix` — fetches Artix Linux mirrors and tests them
 
-5. `rate-mirrors cachyos` -- fetches CachyOS mirrors and tests them
+5. `rate-mirrors cachyos` — fetches CachyOS mirrors and tests them
 
-6. `rate-mirrors endeavouros` -- fetches/reads EndeavourOS mirrors, skips outdated ones and tests them
+6. `rate-mirrors endeavouros` — fetches/reads EndeavourOS mirrors, skips outdated ones and tests them
 
-7. `rate-mirrors stdin` -- takes mirrors from stdin
+7. `rate-mirrors debian` — fetches Debian mirrors and tests them
+
+8. `rate-mirrors stdin` — fetches Ubuntu mirrors and tests them
+
+9. `rate-mirrors stdin` — takes mirrors from stdin
 
    Each string should comply with one of two supported formats:
 
     - tab-separated url and country (either name or country code)
-    - tab-separated country and url -- just in case :)
+    - tab-separated country and url — just in case :)
     - url
 
    e.g. we have a file with mirrors and we'd like to test it & format output for Arch:

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,12 @@ impl From<reqwest::Error> for AppError {
 }
 
 #[delegatable_trait]
+pub trait LogFormatter {
+    fn format_comment(&self, message: impl fmt::Display) -> String;
+    fn format_mirror(&self, mirror: &Mirror) -> String;
+}
+
+#[delegatable_trait]
 pub trait FetchMirrors {
     fn fetch_mirrors(
         &self,
@@ -88,6 +94,7 @@ pub trait FetchMirrors {
 
 #[derive(Debug, StructOpt, Clone, Delegate)]
 #[delegate(FetchMirrors)]
+#[delegate(LogFormatter)]
 pub enum Target {
     /// accepts lines of urls OR lines with tab-separated urls and countries
     Stdin(StdinTarget),
@@ -110,23 +117,6 @@ pub enum Target {
     Ubuntu(UbuntuTarget),
     /// fetch & test debian mirrors
     Debian(DebianTarget),
-}
-
-impl Target {
-    pub fn get_formatter(&self) -> crate::LogFormatter {
-        let comment_prefix = match self {
-            Self::Stdin(t) => &t.comment_prefix,
-            Self::Arch(t) => &t.comment_prefix,
-            Self::Manjaro(t) => &t.comment_prefix,
-            Self::RebornOS(t) => &t.comment_prefix,
-            Self::Artix(t) => &t.comment_prefix,
-            Self::CachyOS(t) => &t.comment_prefix,
-            Self::EndeavourOS(t) => &t.comment_prefix,
-            Self::Ubuntu(t) => &t.comment_prefix,
-            Self::Debian(t) => &t.comment_prefix,
-        };
-        crate::LogFormatter::new(comment_prefix)
-    }
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use crate::mirror::Mirror;
 use crate::target_configs::archlinux::ArchTarget;
 use crate::target_configs::artix::ArtixTarget;
 use crate::target_configs::cachyos::CachyOSTarget;
+use crate::target_configs::debian::DebianTarget;
 use crate::target_configs::endeavouros::EndeavourOSTarget;
 use crate::target_configs::manjaro::ManjaroTarget;
 use crate::target_configs::rebornos::RebornOSTarget;
@@ -57,7 +58,7 @@ pub enum AppError {
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error("failed to parse {0}")]
-    ParseError(String)
+    ParseError(String),
 }
 
 impl fmt::Debug for AppError {
@@ -107,6 +108,8 @@ pub enum Target {
     EndeavourOS(EndeavourOSTarget),
     /// fetch & test ubuntu mirrors
     Ubuntu(UbuntuTarget),
+    /// fetch & test debian mirrors
+    Debian(DebianTarget),
 }
 
 impl Target {

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,7 +114,18 @@ pub enum Target {
 
 impl Target {
     pub fn get_formatter(&self) -> crate::LogFormatter {
-        crate::LogFormatter::new("# ")
+        let comment_prefix = match self {
+            Self::Stdin(t) => &t.comment_prefix,
+            Self::Arch(t) => &t.comment_prefix,
+            Self::Manjaro(t) => &t.comment_prefix,
+            Self::RebornOS(t) => &t.comment_prefix,
+            Self::Artix(t) => &t.comment_prefix,
+            Self::CachyOS(t) => &t.comment_prefix,
+            Self::EndeavourOS(t) => &t.comment_prefix,
+            Self::Ubuntu(t) => &t.comment_prefix,
+            Self::Debian(t) => &t.comment_prefix,
+        };
+        crate::LogFormatter::new(comment_prefix)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,17 @@
 #[macro_use]
 extern crate lazy_static;
-extern crate reqwest;
+
 mod config;
 mod countries;
+mod mirror;
 mod speed_test;
 mod target_configs;
 mod targets;
-use crate::speed_test::{test_speed_by_countries, SpeedTestResult, SpeedTestResults};
-use crate::targets::archlinux::fetch_arch_mirrors;
-use crate::targets::artix::fetch_mirrors as fetch_artix_mirrors;
-use crate::targets::cachyos::fetch_cachyos_mirrors;
-use crate::targets::endeavouros::fetch_mirrors as fetch_endeavouros_mirrors;
-use crate::targets::manjaro::fetch_manjaro_mirrors;
-use crate::targets::rebornos::fetch_rebornos_mirrors;
-use crate::targets::stdin::read_mirrors;
+
+use crate::config::{AppError, Config, FetchMirrors};
+use crate::speed_test::{test_speed_by_countries, SpeedTestResults};
 use chrono::prelude::*;
-use config::{Config, Target};
+use config::Target;
 use nix::unistd::Uid;
 use std::env;
 use std::fmt::Display;
@@ -32,11 +28,8 @@ struct OutputSink {
     comment_prefix: String,
 }
 impl OutputSink {
-    fn new<T>(comment_prefix: T, filename: Option<&str>) -> Result<Self, io::Error>
-    where
-        T: AsRef<str>,
-    {
-        let comment_prefix = comment_prefix.as_ref().to_owned();
+    fn new(comment_prefix: &str, filename: Option<&str>) -> Result<Self, io::Error> {
+        let comment_prefix = comment_prefix.to_string();
         let output = match filename {
             Some(filename) => {
                 let file = File::create(String::from(filename))?;
@@ -52,27 +45,16 @@ impl OutputSink {
         };
         Ok(output)
     }
-    #[inline]
-    fn _consume<T>(&mut self, line: T)
-    where
-        T: AsRef<str> + Display,
-    {
-        let line = line.as_ref();
+    fn _consume(&mut self, line: impl Display) {
         print!("{}", line);
         if let Some(f) = &mut self.file {
-            f.write_all(line.as_bytes()).unwrap();
+            f.write_all(line.to_string().as_bytes()).unwrap();
         }
     }
-    fn consume<T>(&mut self, line: T)
-    where
-        T: AsRef<str> + Display,
-    {
+    fn consume(&mut self, line: impl Display) {
         self._consume(format!("{}\n", line));
     }
-    fn consume_comment<T>(&mut self, line: T)
-    where
-        T: AsRef<str> + Display,
-    {
+    fn consume_comment(&mut self, line: impl Display) {
         self._consume(format!("{}{}\n", &self.comment_prefix, line));
     }
 }
@@ -100,63 +82,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (tx_progress, rx_progress) = mpsc::channel::<String>();
     let (tx_results, rx_results) = mpsc::channel::<SpeedTestResults>();
 
-    let thread_handle = thread::spawn(move || {
-        let mirrors = match &config.target {
-            Target::Arch(target) => fetch_arch_mirrors(
-                Arc::clone(&config),
-                target.clone(),
-                mpsc::Sender::clone(&tx_progress),
-            ),
-            Target::Stdin(target) => read_mirrors(
-                Arc::clone(&config),
-                target.clone(),
-                mpsc::Sender::clone(&tx_progress),
-            ),
-            Target::Manjaro(target) => fetch_manjaro_mirrors(
-                Arc::clone(&config),
-                target.clone(),
-                mpsc::Sender::clone(&tx_progress),
-            ),
-            Target::RebornOS(target) => fetch_rebornos_mirrors(
-                Arc::clone(&config),
-                target.clone(),
-                mpsc::Sender::clone(&tx_progress),
-            ),
-            Target::Artix(target) => fetch_artix_mirrors(
-                Arc::clone(&config),
-                target.clone(),
-                mpsc::Sender::clone(&tx_progress),
-            ),
-            Target::CachyOS(target) => fetch_cachyos_mirrors(
-                Arc::clone(&config),
-                target.clone(),
-                mpsc::Sender::clone(&tx_progress),
-            ),
-            Target::EndeavourOS(target) => fetch_endeavouros_mirrors(
-                Arc::clone(&config),
-                target.clone(),
-                mpsc::Sender::clone(&tx_progress),
-            ),
-        };
-        test_speed_by_countries(
-            mirrors,
-            Arc::clone(&config),
-            mpsc::Sender::clone(&tx_progress),
-            mpsc::Sender::clone(&tx_results),
-        );
+    let thread_handle = thread::spawn(move || -> Result<(), AppError> {
+        let mirrors = config
+            .target
+            .fetch_mirrors(Arc::clone(&config), tx_progress.clone())?;
+        test_speed_by_countries(mirrors, config, tx_progress, tx_results);
+        Ok(())
     });
 
     for progress in rx_progress.into_iter() {
-        output.consume_comment(format!("{}", progress));
+        output.consume_comment(progress.to_string());
     }
 
-    thread_handle.join().unwrap();
-    let results = rx_results
-        .iter()
-        .map(|r| r.results)
-        .flatten()
-        .collect::<Vec<SpeedTestResult>>();
-    output.consume_comment(format!("==== RESULTS (top re-tested) ===="));
+    thread_handle.join().unwrap()?;
+
+    let results: Vec<_> = rx_results.iter().flatten().collect();
+
+    output.consume_comment("==== RESULTS (top re-tested) ====".to_string());
 
     for (index, result) in results.iter().enumerate() {
         match result.item.country {
@@ -182,7 +124,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     output.consume_comment(format!("FINISHED AT: {}", Local::now()));
 
     for result in results.into_iter() {
-        output.consume(result.item.output);
+        output.consume(result.item);
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,11 @@ fn main() -> Result<(), AppError> {
         let mirrors = config
             .target
             .fetch_mirrors(Arc::clone(&config), tx_progress.clone())?;
+
+        tx_progress
+            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", mirrors.len()))
+            .unwrap();
+
         test_speed_by_countries(mirrors, config, tx_progress, tx_results);
         Ok(())
     });

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -1,0 +1,77 @@
+use crate::countries::Country;
+use std::fmt;
+use url::Url;
+
+#[derive(Debug)]
+pub struct MirrorInfo {
+    pub url: Url,
+    pub country: Option<&'static Country>,
+}
+
+impl MirrorInfo {
+    pub fn new(url: Url, country: Option<&str>) -> Self {
+        let country = country.and_then(Country::from_str);
+        Self { url, country }
+    }
+
+    pub fn parse(input: &str, sep: &str) -> Result<Self, MirrorParseError> {
+        let args = input.trim().split(sep).collect::<Vec<_>>();
+
+        match args.len() {
+            1 => match Url::parse(args[0]) {
+                Ok(url) => Ok(MirrorInfo::new(url, None)),
+                Err(_) => Err(MirrorParseError::BadUrl(args[0].to_string())),
+            },
+            2 => match Url::parse(args[0]) {
+                Ok(url) => Ok(MirrorInfo::new(url, Some(args[1]))),
+                Err(_) => match Url::parse(args[1]) {
+                    Ok(url) => Ok(MirrorInfo::new(url, Some(args[0]))),
+                    Err(_) => Err(MirrorParseError::BadUrl(args[1].to_string())),
+                },
+            },
+            _ => Err(MirrorParseError::BadLine(input.to_string())),
+        }
+    }
+}
+
+impl fmt::Display for MirrorInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.country {
+            Some(country) => {
+                write!(f, "[{}] {}", country.code, &self.url)
+            }
+            None => {
+                write!(f, "{}", &self.url)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum MirrorParseError {
+    BadLine(String),
+    BadUrl(String),
+}
+
+impl fmt::Display for MirrorParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MirrorParseError::BadLine(s) => write!(f, "Bad line: {}", s),
+            MirrorParseError::BadUrl(s) => write!(f, "Bad url: {}", s),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Mirror {
+    pub url: Url,
+    pub country: Option<&'static Country>,
+    pub url_to_test: Url,
+    pub output: String,
+}
+
+impl fmt::Display for Mirror {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.output)
+    }
+}

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -65,13 +65,6 @@ impl fmt::Display for MirrorParseError {
 #[derive(Clone, Debug)]
 pub struct Mirror {
     pub url: Url,
-    pub country: Option<&'static Country>,
     pub url_to_test: Url,
-    pub output: String,
-}
-
-impl fmt::Display for Mirror {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.output)
-    }
+    pub country: Option<&'static Country>,
 }

--- a/src/speed_test.rs
+++ b/src/speed_test.rs
@@ -303,7 +303,7 @@ pub fn test_speed_by_countries(
         let current_countries = countries_to_check;
         countries_to_check = Vec::new();
 
-        let mirrors_to_check: Vec<_> = current_countries
+        let mirrors_to_check: Vec<Mirror> = current_countries
             .into_iter()
             .map(|country| {
                 let explored = explored_countries.contains(country.code);
@@ -327,7 +327,6 @@ pub fn test_speed_by_countries(
                                 .iter()
                                 .take(config.country_test_mirrors_per_country)
                                 .cloned()
-                                .collect::<Vec<_>>()
                         })
                         .into_iter()
                         .flatten()
@@ -388,10 +387,9 @@ pub fn test_speed_by_countries(
                 mirrors_of_country
                     .into_iter()
                     .chain(mirrors_of_neighbors.into_iter())
-                    .collect::<Vec<_>>()
             })
             .flatten()
-            .collect::<Vec<_>>();
+            .collect();
 
         tested_urls.extend(mirrors_to_check.iter().map(|m| m.url_to_test.to_string()));
 
@@ -476,7 +474,7 @@ pub fn test_speed_by_countries(
         let speed_check_sensitivity = 1.2;
         let connection_time_check_sensitivity = 1.5;
         // BY CONNECTION TIME
-        let connection_times_state = latest_top_connection_times
+        let connection_times_state: Vec<bool> = latest_top_connection_times
             .iter()
             .rev()
             .zip(latest_top_connection_times.iter().rev().skip(1))
@@ -484,7 +482,7 @@ pub fn test_speed_by_countries(
                 next.as_secs_f64() > prev.as_secs_f64() * connection_time_check_sensitivity
             })
             .take(connection_time_checks)
-            .collect::<Vec<bool>>();
+            .collect();
         if connection_times_state.len() == connection_time_checks
             && connection_times_state.iter().all(|b| *b)
         {
@@ -495,13 +493,13 @@ pub fn test_speed_by_countries(
         }
 
         // BY SPEED
-        let speeds_state = latest_top_speeds
+        let speeds_state: Vec<bool> = latest_top_speeds
             .iter()
             .rev()
             .zip(latest_top_speeds.iter().rev().skip(1))
             .map(|(next, prev)| *next as f64 * speed_check_sensitivity < *prev as f64)
             .take(speed_checks)
-            .collect::<Vec<bool>>();
+            .collect();
         if speeds_state.len() == speed_checks && speeds_state.iter().all(|b| *b) {
             tx_progress
                 .send("SPEEDS ARE GETTING WORSE, STOPPING".to_string())
@@ -524,7 +522,7 @@ pub fn test_speed_by_countries(
             ))
             .unwrap();
         for mirrors in map.into_values() {
-            let mut untested_mirrors: Vec<_> = mirrors
+            let mut untested_mirrors: Vec<Mirror> = mirrors
                 .into_iter()
                 .filter(|m| !tested_urls.contains(m.url_to_test.as_str()))
                 .collect();

--- a/src/target_configs/debian.rs
+++ b/src/target_configs/debian.rs
@@ -1,8 +1,27 @@
-use super::debian::SourceListEntriesOpts;
 use structopt::StructOpt;
 
 #[derive(Debug, Clone, StructOpt)]
-pub struct UbuntuTarget {
+pub struct SourceListEntriesOpts {
+    /// The deb type references a typical two-level Debian archive, distribution/component
+    /// deb-src type references a Debian distribution's source code
+    #[structopt(long = "types", default_value = "deb", verbatim_doc_comment)]
+    pub types: Vec<String>,
+
+    /// options specified to modify which source is accessed and how data is acquired from it
+    #[structopt(long = "options")]
+    pub options: Vec<String>,
+
+    /// suite name like stable or testing or a codename like jessie or stretch
+    #[structopt(long = "suites", required = true)]
+    pub suites: Vec<String>,
+
+    /// archive components like main, restricted, universe and multiverse
+    #[structopt(long = "components", default_value = "main")]
+    pub components: Vec<String>,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct DebianTarget {
     #[structopt(flatten)]
     pub source_list_opts: SourceListEntriesOpts,
 

--- a/src/target_configs/manjaro.rs
+++ b/src/target_configs/manjaro.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 use structopt::StructOpt;
 
 #[derive(Debug, Clone)]
@@ -19,13 +19,14 @@ impl FromStr for ManjaroBranch {
     }
 }
 
-impl ManjaroBranch {
-    pub fn as_str(&self) -> &'static str {
-        match self {
+impl fmt::Display for ManjaroBranch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let repr = match self {
             ManjaroBranch::Stable => "stable",
             ManjaroBranch::Testing => "testing",
             ManjaroBranch::Unstable => "unstable",
-        }
+        };
+        write!(f, "{}", repr)
     }
 }
 

--- a/src/target_configs/manjaro.rs
+++ b/src/target_configs/manjaro.rs
@@ -18,6 +18,7 @@ impl FromStr for ManjaroBranch {
         }
     }
 }
+
 impl ManjaroBranch {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -32,12 +33,12 @@ impl ManjaroBranch {
 pub struct ManjaroTarget {
     /// Fetch list of mirrors timeout in milliseconds
     #[structopt(long = "fetch-mirrors-timeout", default_value = "15000")]
-    pub fetch_mirrors_timeout: usize,
+    pub fetch_mirrors_timeout: u64,
 
     /// Max acceptable delay in seconds since the last time a mirror has been
     /// synced
     #[structopt(long = "max-delay", default_value = "86400")]
-    pub max_delay: usize,
+    pub max_delay: u64,
 
     /// Path to be joined to a mirror url and used for speed testing
     ///   the file should be big enough to allow for testing high

--- a/src/target_configs/mod.rs
+++ b/src/target_configs/mod.rs
@@ -1,6 +1,7 @@
 pub mod archlinux;
 pub mod artix;
 pub mod cachyos;
+pub mod debian;
 pub mod endeavouros;
 pub mod manjaro;
 pub mod rebornos;

--- a/src/target_configs/mod.rs
+++ b/src/target_configs/mod.rs
@@ -5,3 +5,4 @@ pub mod endeavouros;
 pub mod manjaro;
 pub mod rebornos;
 pub mod stdin;
+pub mod ubuntu;

--- a/src/target_configs/stdin.rs
+++ b/src/target_configs/stdin.rs
@@ -19,6 +19,7 @@ pub struct StdinTarget {
     #[structopt(long = "output-prefix", default_value = "")]
     pub output_prefix: String,
 
+    /// input separator to use when parsing mirrors list
     #[structopt(long = "separator", default_value = "\t")]
-    pub separator: String,
+    pub input_separator: String,
 }

--- a/src/target_configs/stdin.rs
+++ b/src/target_configs/stdin.rs
@@ -18,4 +18,7 @@ pub struct StdinTarget {
     /// output prefix to use when printing results
     #[structopt(long = "output-prefix", default_value = "")]
     pub output_prefix: String,
+
+    #[structopt(long = "separator", default_value = "\t")]
+    pub separator: String,
 }

--- a/src/target_configs/ubuntu.rs
+++ b/src/target_configs/ubuntu.rs
@@ -1,0 +1,44 @@
+use structopt::StructOpt;
+
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct UbuntuTarget {
+    /// The deb type references a typical two-level Debian archive, distribution/component
+    /// deb-src type references a Debian distribution's source code
+    #[structopt(long = "types", default_value = "deb", verbatim_doc_comment)]
+    pub types: Vec<String>,
+
+    /// options specified to modify which source is accessed and how data is acquired from it
+    #[structopt(long = "options")]
+    pub options: Vec<String>,
+
+    /// suite name like stable or testing or a codename like jessie or stretch
+    #[structopt(long = "suites", required = true)]
+    pub suites: Vec<String>,
+
+    /// archive components like main, restricted, universe and multiverse
+    #[structopt(long = "components", default_value = "main")]
+    pub components: Vec<String>,
+
+    /// Max acceptable delay in seconds since the last time a mirror has been synced
+    #[structopt(long = "max-delay", default_value = "86400")]
+    pub max_delay: u64,
+
+    /// Path to be joined to a mirror url and used for speed testing
+    ///   the file should be big enough to allow for testing high
+    ///   speed connections
+    #[structopt(
+        long = "path-to-test",
+        default_value = "ubuntu/ls-lR.gz",
+        verbatim_doc_comment
+    )]
+    pub path_to_test: String,
+
+    /// Fetch list of mirrors timeout in milliseconds
+    #[structopt(long = "fetch-mirrors-timeout", default_value = "15000")]
+    pub fetch_mirrors_timeout: u64,
+
+    /// comment prefix to use when outputting
+    #[structopt(long = "comment-prefix", default_value = "# ")]
+    pub comment_prefix: String,
+}

--- a/src/targets/archlinux.rs
+++ b/src/targets/archlinux.rs
@@ -90,6 +90,7 @@ impl FetchMirrors for ArchTarget {
                 mirrors.sort_unstable_by(|a, b| a.score.partial_cmp(&b.score).unwrap());
             }
         };
+
         let result: Vec<_> = mirrors
             .into_iter()
             .filter_map(|m| {
@@ -106,9 +107,7 @@ impl FetchMirrors for ArchTarget {
                 None
             })
             .collect();
-        tx_progress
-            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
-            .unwrap();
+
         Ok(result)
     }
 }

--- a/src/targets/archlinux.rs
+++ b/src/targets/archlinux.rs
@@ -1,4 +1,4 @@
-use crate::config::{AppError, Config, FetchMirrors};
+use crate::config::{AppError, Config, FetchMirrors, LogFormatter};
 use crate::countries::Country;
 use crate::mirror::Mirror;
 use crate::target_configs::archlinux::{ArchMirrorsSortingStrategy, ArchTarget};
@@ -6,6 +6,7 @@ use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use reqwest;
 use serde::Deserialize;
+use std::fmt::Display;
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
 use tokio::runtime::Runtime;
@@ -28,6 +29,16 @@ pub struct ArchMirror {
 #[derive(Deserialize, Debug)]
 struct ArchMirrorsData {
     urls: Vec<ArchMirror>,
+}
+
+impl LogFormatter for ArchTarget {
+    fn format_comment(&self, message: impl Display) -> String {
+        format!("{}{}", self.comment_prefix, message)
+    }
+
+    fn format_mirror(&self, mirror: &Mirror) -> String {
+        format!("Server = {}$repo/os/$arch", &mirror.url)
+    }
 }
 
 impl FetchMirrors for ArchTarget {
@@ -98,7 +109,6 @@ impl FetchMirrors for ArchTarget {
                     if let Ok(url_to_test) = url.join(&self.path_to_test) {
                         return Some(Mirror {
                             country: Country::from_str(&m.country_code),
-                            output: format!("Server = {}$repo/os/$arch", &m.url),
                             url,
                             url_to_test,
                         });

--- a/src/targets/artix.rs
+++ b/src/targets/artix.rs
@@ -1,77 +1,57 @@
-use super::stdin::Mirror;
-use crate::config::{Config, Protocol};
+use crate::config::{AppError, Config, FetchMirrors};
+use crate::mirror::Mirror;
 use crate::target_configs::artix::ArtixTarget;
 use reqwest;
-use std::str::FromStr;
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
-use tokio;
 use url::Url;
 
-pub fn fetch_mirrors(
-    config: Arc<Config>,
-    target: ArtixTarget,
-    tx_progress: mpsc::Sender<String>,
-) -> Vec<Mirror> {
-    let runtime = tokio::runtime::Runtime::new().unwrap();
-    let _sth = runtime.enter();
-    let url = "https://gitea.artixlinux.org/packagesA/artix-mirrorlist/raw/branch/master/trunk/mirrorlist";
-    let response = runtime
-        .block_on(
-            reqwest::Client::new()
-                .get(url)
-                .timeout(Duration::from_millis(target.fetch_mirrors_timeout))
-                .send(),
-        )
-        .expect(
-            format!(
-                "failed to connect to {}, consider increasing fetch-mirrors-timeout",
-                url
-            )
-            .as_str(),
-        );
+impl FetchMirrors for ArtixTarget {
+    fn fetch_mirrors(
+        &self,
+        config: Arc<Config>,
+        tx_progress: mpsc::Sender<String>,
+    ) -> Result<Vec<Mirror>, AppError> {
+        let url = "https://gitea.artixlinux.org/packagesA/artix-mirrorlist/raw/branch/master/trunk/mirrorlist";
 
-    let output = runtime
-        .block_on(response.text_with_charset("utf-8"))
-        .expect(format!("failed to fetch mirrors from {}", url).as_str());
+        let output = reqwest::blocking::Client::new()
+            .get(url)
+            .timeout(Duration::from_millis(self.fetch_mirrors_timeout))
+            .send()?
+            .text_with_charset("utf-8")?;
 
-    let fallback_protocols;
-    let allowed_protocols: &[Protocol] = match config.protocols.len() {
-        0 => {
-            fallback_protocols = vec![Protocol::Http, Protocol::Https];
-            &fallback_protocols
-        }
-        _ => &config.protocols,
-    };
+        let urls = output
+            .lines()
+            .filter(|line| !line.starts_with('#'))
+            .map(|line| line.replace("Server = ", "").replace("$repo/os/$arch", ""))
+            .filter(|line| !line.is_empty())
+            .filter_map(|line| Url::parse(&line).ok())
+            .filter(|url| {
+                url.scheme()
+                    .parse()
+                    .map(|p| config.is_protocol_allowed(&p))
+                    .unwrap_or(false)
+            });
 
-    let urls: Vec<Url> = output
-        .lines()
-        .filter(|line| !line.starts_with("#"))
-        .map(|line| line.replace("Server = ", "").replace("$repo/os/$arch", ""))
-        .filter(|line| line.len() > 0)
-        .filter_map(|line| Url::from_str(&line).ok())
-        .filter(|url| match Protocol::from_str(url.scheme()) {
-            Ok(protocol) => allowed_protocols.contains(&protocol),
-            Err(_) => false,
-        })
-        .collect();
+        let result: Vec<_> = urls
+            .map(|url| {
+                let url_to_test = url
+                    .join(&self.path_to_test)
+                    .expect("failed to join path_to_test");
 
-    let result: Vec<Mirror> = urls
-        .into_iter()
-        .filter_map(|url| {
-            let url_to_test = url
-                .join(&target.path_to_test)
-                .expect("failed to join path_to_test");
-            Some(Mirror {
-                country: None,
-                output: format!("Server = {}$repo/os/$arch", &url.as_str()),
-                url,
-                url_to_test,
+                Mirror {
+                    country: None,
+                    output: format!("Server = {}$repo/os/$arch", url),
+                    url_to_test,
+                    url,
+                }
             })
-        })
-        .collect();
-    tx_progress
-        .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
-        .unwrap();
-    result
+            .collect();
+
+        tx_progress
+            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
+            .unwrap();
+
+        Ok(result)
+    }
 }

--- a/src/targets/artix.rs
+++ b/src/targets/artix.rs
@@ -4,6 +4,7 @@ use crate::target_configs::artix::ArtixTarget;
 use reqwest;
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
+use tokio::runtime::Runtime;
 use url::Url;
 
 impl FetchMirrors for ArtixTarget {
@@ -14,11 +15,17 @@ impl FetchMirrors for ArtixTarget {
     ) -> Result<Vec<Mirror>, AppError> {
         let url = "https://gitea.artixlinux.org/packagesA/artix-mirrorlist/raw/branch/master/trunk/mirrorlist";
 
-        let output = reqwest::blocking::Client::new()
-            .get(url)
-            .timeout(Duration::from_millis(self.fetch_mirrors_timeout))
-            .send()?
-            .text_with_charset("utf-8")?;
+        let output = Runtime::new().unwrap().block_on(async {
+            Ok::<_, AppError>(
+                reqwest::Client::new()
+                    .get(url)
+                    .timeout(Duration::from_millis(self.fetch_mirrors_timeout))
+                    .send()
+                    .await?
+                    .text_with_charset("utf-8")
+                    .await?,
+            )
+        })?;
 
         let urls = output
             .lines()

--- a/src/targets/artix.rs
+++ b/src/targets/artix.rs
@@ -11,7 +11,7 @@ impl FetchMirrors for ArtixTarget {
     fn fetch_mirrors(
         &self,
         config: Arc<Config>,
-        tx_progress: mpsc::Sender<String>,
+        _tx_progress: mpsc::Sender<String>,
     ) -> Result<Vec<Mirror>, AppError> {
         let url = "https://gitea.artixlinux.org/packagesA/artix-mirrorlist/raw/branch/master/trunk/mirrorlist";
 
@@ -54,10 +54,6 @@ impl FetchMirrors for ArtixTarget {
                 }
             })
             .collect();
-
-        tx_progress
-            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
-            .unwrap();
 
         Ok(result)
     }

--- a/src/targets/artix.rs
+++ b/src/targets/artix.rs
@@ -1,11 +1,22 @@
-use crate::config::{AppError, Config, FetchMirrors};
+use crate::config::{AppError, Config, FetchMirrors, LogFormatter};
 use crate::mirror::Mirror;
 use crate::target_configs::artix::ArtixTarget;
 use reqwest;
+use std::fmt::Display;
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
 use tokio::runtime::Runtime;
 use url::Url;
+
+impl LogFormatter for ArtixTarget {
+    fn format_comment(&self, message: impl Display) -> String {
+        format!("{}{}", self.comment_prefix, message)
+    }
+
+    fn format_mirror(&self, mirror: &Mirror) -> String {
+        format!("Server = {}$repo/os/$arch", mirror.url)
+    }
+}
 
 impl FetchMirrors for ArtixTarget {
     fn fetch_mirrors(
@@ -48,7 +59,6 @@ impl FetchMirrors for ArtixTarget {
 
                 Mirror {
                     country: None,
-                    output: format!("Server = {}$repo/os/$arch", url),
                     url_to_test,
                     url,
                 }

--- a/src/targets/cachyos.rs
+++ b/src/targets/cachyos.rs
@@ -54,9 +54,7 @@ impl FetchMirrors for CachyOSTarget {
                 }
             })
             .collect();
-        tx_progress
-            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
-            .unwrap();
+
         Ok(result)
     }
 }

--- a/src/targets/cachyos.rs
+++ b/src/targets/cachyos.rs
@@ -1,81 +1,55 @@
-use super::stdin::Mirror;
-use crate::config::{Config, Protocol};
+use crate::config::{AppError, Config, FetchMirrors};
+use crate::mirror::Mirror;
 use crate::target_configs::cachyos::CachyOSTarget;
 use reqwest;
-use std::str::FromStr;
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
-use tokio;
 use url::Url;
 
-pub fn fetch_cachyos_mirrors(
-    config: Arc<Config>,
-    target: CachyOSTarget,
-    tx_progress: mpsc::Sender<String>,
-) -> Vec<Mirror> {
-    let runtime = tokio::runtime::Runtime::new().unwrap();
-    let _sth = runtime.enter();
-    let url = "https://raw.githubusercontent.com/CachyOS/CachyOS-PKGBUILDS/master/cachyos-mirrorlist/cachyos-mirrorlist";
-    let response = runtime
-        .block_on(
-            reqwest::Client::new()
-                .get(url)
-                .timeout(Duration::from_millis(target.fetch_mirrors_timeout))
-                .send(),
-        )
-        .expect(
-            format!(
-                "failed to connect to {}, consider increasing fetch-mirrors-timeout",
-                url
-            )
-            .as_str(),
-        );
+impl FetchMirrors for CachyOSTarget {
+    fn fetch_mirrors(
+        &self,
+        config: Arc<Config>,
+        tx_progress: mpsc::Sender<String>,
+    ) -> Result<Vec<Mirror>, AppError> {
+        let url = "https://raw.githubusercontent.com/CachyOS/CachyOS-PKGBUILDS/master/cachyos-mirrorlist/cachyos-mirrorlist";
 
-    let output = runtime
-        .block_on(response.text_with_charset("utf-8"))
-        .expect(format!("failed to fetch mirrors from {}", url).as_str());
+        let output = reqwest::blocking::Client::new()
+            .get(url)
+            .timeout(Duration::from_millis(self.fetch_mirrors_timeout))
+            .send()?
+            .text_with_charset("utf-8")?;
 
-    let fallback_protocols;
-    let allowed_protocols: &[Protocol] = match config.protocols.len() {
-        0 => {
-            fallback_protocols = vec![Protocol::Http, Protocol::Https];
-            &fallback_protocols
-        }
-        _ => &config.protocols,
-    };
+        let urls = output
+            .lines()
+            .filter(|line| !line.starts_with('#'))
+            .map(|line| line.replace("Server = ", "").replace("$arch/$repo", ""))
+            .filter(|line| !line.is_empty())
+            .filter_map(|line| Url::parse(&line).ok())
+            .filter(|url| config.is_protocol_allowed_for_url(url));
 
-    let urls: Vec<Url> = output
-        .lines()
-        .filter(|line| !line.starts_with("#"))
-        .map(|line| line.replace("Server = ", "").replace("$arch/$repo", ""))
-        .filter(|line| line.len() > 0)
-        .filter_map(|line| Url::from_str(&line).ok())
-        .filter(|url| match Protocol::from_str(url.scheme()) {
-            Ok(protocol) => allowed_protocols.contains(&protocol),
-            Err(_) => false,
-        })
-        .collect();
+        let arch = if self.arch == "auto" {
+            "$arch"
+        } else {
+            &self.arch
+        };
 
-    let arch: String = match target.arch.as_str() {
-        "auto" => String::from("$arch"),
-        _ => String::from(target.arch.as_str()),
-    };
-    let result: Vec<Mirror> = urls
-        .into_iter()
-        .filter_map(|url| {
-            let url_to_test = url
-                .join(&target.path_to_test)
-                .expect("failed to join path_to_test");
-            Some(Mirror {
-                country: None,
-                output: format!("Server = {}{}/$repo", &url.as_str(), &arch.as_str()),
-                url,
-                url_to_test,
+        let result: Vec<_> = urls
+            .map(|url| {
+                let url_to_test = url
+                    .join(&self.path_to_test)
+                    .expect("failed to join path_to_test");
+                Mirror {
+                    country: None,
+                    output: format!("Server = {}{}/$repo", url, arch),
+                    url,
+                    url_to_test,
+                }
             })
-        })
-        .collect();
-    tx_progress
-        .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
-        .unwrap();
-    result
+            .collect();
+        tx_progress
+            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
+            .unwrap();
+        Ok(result)
+    }
 }

--- a/src/targets/debian.rs
+++ b/src/targets/debian.rs
@@ -91,8 +91,6 @@ impl FetchMirrors for DebianTarget {
                     }
                 }
 
-                // println!("[{}] {:?}", country, mirrors);
-
                 Ok(mirrors
                     .into_iter()
                     .filter_map(|url| Url::parse(url).ok())
@@ -107,10 +105,6 @@ impl FetchMirrors for DebianTarget {
             })
             .flatten()
             .collect();
-
-        tx_progress
-            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
-            .unwrap();
 
         Ok(result)
     }

--- a/src/targets/debian.rs
+++ b/src/targets/debian.rs
@@ -1,0 +1,117 @@
+use crate::config::{AppError, Config, FetchMirrors};
+use crate::countries::Country;
+use crate::mirror::Mirror;
+use crate::target_configs::debian::{DebianTarget, SourceListEntriesOpts};
+use itertools::Itertools;
+use reqwest;
+use select::document::Document;
+use select::predicate::{Attr, Name};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use url::Url;
+
+pub fn display_mirror(target: &SourceListEntriesOpts, url: &Url) -> String {
+    // The format for two one-line-style entries using the deb and deb-src types is:
+    //   type [ option1=value1 option2=value2 ] uri suite [component1] [component2] [...]
+    //
+    //   deb [ arch=amd64,armel ] http://us.archive.ubuntu.com/ubuntu trusty main restricted
+
+    let ref options = if target.options.len() > 0 {
+        format!(" [{}] ", target.options.join(" "))
+    } else {
+        " ".to_string()
+    };
+
+    let ref components = target.components.join(" ");
+
+    target
+        .types
+        .iter()
+        .flat_map(|type_| {
+            target
+                .suites
+                .iter()
+                .map(move |suite| format!("{}{}{} {} {}", type_, options, url, suite, components))
+        })
+        .join("\n")
+}
+
+impl FetchMirrors for DebianTarget {
+    fn fetch_mirrors(
+        &self,
+        config: Arc<Config>,
+        tx_progress: mpsc::Sender<String>,
+    ) -> Result<Vec<Mirror>, AppError> {
+        let url = "https://www.debian.org/mirror/mirrors_full";
+
+        let output = Runtime::new().unwrap().block_on(async {
+            Ok::<_, AppError>(
+                reqwest::Client::new()
+                    .get(url)
+                    .timeout(Duration::from_millis(self.fetch_mirrors_timeout))
+                    .send()
+                    .await?
+                    .text_with_charset("utf-8")
+                    .await?,
+            )
+        })?;
+
+        let document = Document::from(output.as_str());
+
+        let content = document
+            .find(Attr("id", "content"))
+            .next()
+            .ok_or(AppError::ParseError("mirror list".to_string()))?;
+
+        let result: Vec<_> = content
+            .find(Name("h3"))
+            .flat_map(|head| -> Result<_, AppError> {
+                let country = head.text();
+
+                let mut mirrors = Vec::new();
+                let mut current = head;
+
+                loop {
+                    current = match current.next() {
+                        None => break,
+                        Some(node) => node,
+                    };
+
+                    if current.is(Name("tt")) {
+                        if let Some(link) = current.find(Name("a")).next() {
+                            if link.text().contains("/debian/") {
+                                mirrors.push(link.attr("href").unwrap());
+                            }
+                        }
+                    }
+
+                    if current.is(Name("h3")) {
+                        break;
+                    }
+                }
+
+                // println!("[{}] {:?}", country, mirrors);
+
+                Ok(mirrors
+                    .into_iter()
+                    .filter_map(|url| Url::parse(url).ok())
+                    .filter(|url| config.is_protocol_allowed_for_url(url))
+                    .map(|url| Mirror {
+                        country: Country::from_str(&country),
+                        output: display_mirror(&self.source_list_opts, &url),
+                        url_to_test: url.join(&self.path_to_test).unwrap(),
+                        url,
+                    })
+                    .collect::<Vec<_>>())
+            })
+            .flatten()
+            .collect();
+
+        tx_progress
+            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
+            .unwrap();
+
+        Ok(result)
+    }
+}

--- a/src/targets/endeavouros.rs
+++ b/src/targets/endeavouros.rs
@@ -175,10 +175,6 @@ impl FetchMirrors for EndeavourOSTarget {
             Vec::new()
         };
 
-        tx_progress
-            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", mirrors.len()))
-            .unwrap();
-
         Ok(mirrors)
     }
 }

--- a/src/targets/endeavouros.rs
+++ b/src/targets/endeavouros.rs
@@ -1,9 +1,10 @@
-use crate::config::{AppError, Config, FetchMirrors};
+use crate::config::{AppError, Config, FetchMirrors, LogFormatter};
 use crate::countries::Country;
 use crate::mirror::Mirror;
 use crate::target_configs::endeavouros::EndeavourOSTarget;
 use futures::future::join_all;
 use reqwest;
+use std::fmt::Display;
 use std::fs;
 use std::str::FromStr;
 use std::sync::{mpsc, Arc};
@@ -90,6 +91,16 @@ fn version_mirrors(
         .collect::<Vec<_>>()
 }
 
+impl LogFormatter for EndeavourOSTarget {
+    fn format_comment(&self, message: impl Display) -> String {
+        format!("{}{}", self.comment_prefix, message)
+    }
+
+    fn format_mirror(&self, mirror: &Mirror) -> String {
+        format!("Server = {}$repo/$arch", &mirror.url)
+    }
+}
+
 impl FetchMirrors for EndeavourOSTarget {
     fn fetch_mirrors(
         &self,
@@ -136,7 +147,6 @@ impl FetchMirrors for EndeavourOSTarget {
                             .expect("failed to join path_to_test");
                         mirrors.push(Mirror {
                             country: current_country,
-                            output: format!("Server = {}$repo/$arch", &url.as_str()),
                             url,
                             url_to_test,
                         });

--- a/src/targets/manjaro.rs
+++ b/src/targets/manjaro.rs
@@ -98,10 +98,6 @@ impl FetchMirrors for ManjaroTarget {
             })
             .collect();
 
-        tx_progress
-            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", mirrors.len()))
-            .unwrap();
-
         Ok(mirrors)
     }
 }

--- a/src/targets/mod.rs
+++ b/src/targets/mod.rs
@@ -1,6 +1,7 @@
 pub mod archlinux;
 pub mod artix;
 pub mod cachyos;
+pub mod debian;
 pub mod endeavouros;
 pub mod manjaro;
 pub mod rebornos;

--- a/src/targets/mod.rs
+++ b/src/targets/mod.rs
@@ -5,3 +5,4 @@ pub mod endeavouros;
 pub mod manjaro;
 pub mod rebornos;
 pub mod stdin;
+pub mod ubuntu;

--- a/src/targets/rebornos.rs
+++ b/src/targets/rebornos.rs
@@ -11,7 +11,7 @@ impl FetchMirrors for RebornOSTarget {
     fn fetch_mirrors(
         &self,
         config: Arc<Config>,
-        tx_progress: mpsc::Sender<String>,
+        _tx_progress: mpsc::Sender<String>,
     ) -> Result<Vec<Mirror>, AppError> {
         let url = "https://gitlab.com/rebornos-team/rebornos-special-system-files/mirrors/reborn-mirrorlist/-/raw/master/reborn-mirrorlist";
 
@@ -43,10 +43,6 @@ impl FetchMirrors for RebornOSTarget {
                 url,
             })
             .collect();
-
-        tx_progress
-            .send(format!("FETCHED {} MIRRORS FROM REBORNOS", mirrors.len()))
-            .unwrap();
 
         Ok(mirrors)
     }

--- a/src/targets/rebornos.rs
+++ b/src/targets/rebornos.rs
@@ -1,80 +1,45 @@
-use super::stdin::Mirror;
-use crate::config::{Config, Protocol};
+use crate::config::{AppError, Config, FetchMirrors};
+use crate::mirror::Mirror;
 use crate::target_configs::rebornos::RebornOSTarget;
 use linkify::{LinkFinder, LinkKind};
-use std::str::FromStr;
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
 use url::Url;
 
-fn text_from_url(url: Url, timeout: u64) -> String {
-    let runtime = tokio::runtime::Runtime::new().unwrap();
-    let _sth = runtime.enter();
-    let response = runtime
-        .block_on(
-            reqwest::Client::new()
-                .get(url.as_str())
-                .timeout(Duration::from_millis(timeout))
-                .send(),
-        )
-        .expect(
-            format!(
-                "failed to connect to {}, consider increasing fetch-mirrors-timeout",
-                url.as_str()
-            )
-            .as_str(),
-        );
+impl FetchMirrors for RebornOSTarget {
+    fn fetch_mirrors(
+        &self,
+        config: Arc<Config>,
+        tx_progress: mpsc::Sender<String>,
+    ) -> Result<Vec<Mirror>, AppError> {
+        let url = "https://gitlab.com/rebornos-team/rebornos-special-system-files/mirrors/reborn-mirrorlist/-/raw/master/reborn-mirrorlist";
+        let mirrorlist_file_text = reqwest::blocking::Client::new()
+            .get(url)
+            .timeout(Duration::from_millis(self.fetch_mirrors_timeout))
+            .send()?
+            .text_with_charset("utf-16")?;
 
-    return runtime
-        .block_on(response.text_with_charset("utf-16"))
-        .expect(format!("failed to fetch from {}", url.as_str()).as_str());
-}
+        let mut link_finder = LinkFinder::new();
+        link_finder.kinds(&[LinkKind::Url]);
 
-pub fn fetch_rebornos_mirrors(
-    config: Arc<Config>,
-    target: RebornOSTarget,
-    tx_progress: mpsc::Sender<String>,
-) -> Vec<Mirror> {
-    let fallback_protocols;
-    let allowed_protocols: &[Protocol] = match config.protocols.len() {
-        0 => {
-            fallback_protocols = vec![Protocol::Http, Protocol::Https];
-            &fallback_protocols
-        }
-        _ => &config.protocols,
-    };
-
-    let mirrorlist_file_text = text_from_url(
-        Url::from_str(
-            "https://gitlab.com/rebornos-team/rebornos-special-system-files/mirrors/reborn-mirrorlist/-/raw/master/reborn-mirrorlist"
-        ).unwrap(),
-        target.fetch_mirrors_timeout
-    );
-
-    let mut link_finder = LinkFinder::new();
-    link_finder.kinds(&[LinkKind::Url]);
-    let url_iter = link_finder
-        .links(&mirrorlist_file_text)
-        .filter_map(|url| Url::from_str(url.as_str()).ok());
-
-    let mirrors: Vec<Mirror> = url_iter
-        .filter_map(|url| {
-            Some(Mirror {
+        let mirrors: Vec<_> = link_finder
+            .links(&mirrorlist_file_text)
+            .filter_map(|url| Url::parse(url.as_str()).ok())
+            .filter(|url| config.is_protocol_allowed_for_url(url))
+            .map(|url| Mirror {
                 country: None,
-                output: format!("Server = {}", url.as_str().to_owned()),
+                output: format!("Server = {}", url),
                 url_to_test: url
-                    .join(&target.path_to_test)
+                    .join(&self.path_to_test)
                     .expect("failed to join path-to-test"),
                 url,
             })
-        })
-        .filter(|mirror| {
-            allowed_protocols.contains(&Protocol::from_str(mirror.url.scheme()).unwrap())
-        })
-        .collect();
-    tx_progress
-        .send(format!("FETCHED {} MIRRORS FROM REBORNOS", mirrors.len()))
-        .unwrap();
+            .collect();
 
-    mirrors
+        tx_progress
+            .send(format!("FETCHED {} MIRRORS FROM REBORNOS", mirrors.len()))
+            .unwrap();
+
+        Ok(mirrors)
+    }
 }

--- a/src/targets/rebornos.rs
+++ b/src/targets/rebornos.rs
@@ -1,11 +1,22 @@
-use crate::config::{AppError, Config, FetchMirrors};
+use crate::config::{AppError, Config, FetchMirrors, LogFormatter};
 use crate::mirror::Mirror;
 use crate::target_configs::rebornos::RebornOSTarget;
 use linkify::{LinkFinder, LinkKind};
+use std::fmt::Display;
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
 use tokio::runtime::Runtime;
 use url::Url;
+
+impl LogFormatter for RebornOSTarget {
+    fn format_comment(&self, message: impl Display) -> String {
+        format!("{}{}", self.comment_prefix, message)
+    }
+
+    fn format_mirror(&self, mirror: &Mirror) -> String {
+        format!("Server = {}", mirror.url)
+    }
+}
 
 impl FetchMirrors for RebornOSTarget {
     fn fetch_mirrors(
@@ -36,7 +47,6 @@ impl FetchMirrors for RebornOSTarget {
             .filter(|url| config.is_protocol_allowed_for_url(url))
             .map(|url| Mirror {
                 country: None,
-                output: format!("Server = {}", url),
                 url_to_test: url
                     .join(&self.path_to_test)
                     .expect("failed to join path-to-test"),

--- a/src/targets/stdin.rs
+++ b/src/targets/stdin.rs
@@ -9,7 +9,7 @@ impl FetchMirrors for StdinTarget {
     fn fetch_mirrors(
         &self,
         config: Arc<Config>,
-        tx_progress: mpsc::Sender<String>,
+        _tx_progress: mpsc::Sender<String>,
     ) -> Result<Vec<Mirror>, AppError> {
         let mirrors: Vec<_> = io::stdin()
             .lock()
@@ -39,9 +39,7 @@ impl FetchMirrors for StdinTarget {
             )
             .filter(|mirror| config.is_protocol_allowed_for_url(&mirror.url))
             .collect();
-        tx_progress
-            .send(format!("READ {} MIRRORS FROM STDIN", mirrors.len()))
-            .unwrap();
+
         Ok(mirrors)
     }
 }

--- a/src/targets/stdin.rs
+++ b/src/targets/stdin.rs
@@ -1,122 +1,47 @@
-use crate::config::{Config, Protocol};
-use crate::countries::Country;
+use crate::config::{AppError, Config, FetchMirrors};
 use crate::target_configs::stdin::StdinTarget;
-use std::fmt;
 use std::io::{self, BufRead};
-use std::str::FromStr;
 use std::sync::{mpsc, Arc};
-use url::Url;
 
-#[derive(Clone, Debug)]
-pub struct Mirror {
-    pub country: Option<&'static Country>,
-    pub output: String,
-    pub url: Url,
-    pub url_to_test: Url,
-}
+use crate::mirror::{Mirror, MirrorInfo};
 
-impl fmt::Display for Mirror {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.country {
-            Some(country) => {
-                write!(f, "[{}] {}", country.code, &self.url)
-            }
-            None => {
-                write!(f, "{}", &self.url)
-            }
-        }
-    }
-}
-
-impl Mirror {
-    pub fn line_to_mirror_info<T>(line: T) -> Result<(Url, Option<&'static Country>), &'static str>
-    where
-        T: AsRef<str>,
-    {
-        let args: Vec<&str> = line.as_ref().trim().split("\t").collect();
-        match args.len() {
-            1 => match Url::parse(args[0]) {
-                Ok(url) => Ok((url, None)),
-                Err(_) => {
-                    eprintln!("skipping input line: bad url {}", args.join("\t"));
-                    return Err("bad url");
-                }
-            },
-            2 => {
-                let country_index;
-                let url = match Url::parse(args[0]) {
-                    Ok(url) => {
-                        country_index = 1;
-                        url
+impl FetchMirrors for StdinTarget {
+    fn fetch_mirrors(
+        &self,
+        config: Arc<Config>,
+        tx_progress: mpsc::Sender<String>,
+    ) -> Result<Vec<Mirror>, AppError> {
+        let mirrors: Vec<_> = io::stdin()
+            .lock()
+            .lines()
+            .filter_map(
+                |line| match MirrorInfo::parse(&line.unwrap(), &self.separator) {
+                    Ok(info) => Some(Mirror {
+                        country: info.country,
+                        output: format!(
+                            "{}{}",
+                            self.output_prefix,
+                            info.url
+                                .join(&self.path_to_return)
+                                .expect("failed to join path-to-return")
+                        ),
+                        url_to_test: info
+                            .url
+                            .join(&self.path_to_return)
+                            .expect("failed to join path-to-return"),
+                        url: info.url,
+                    }),
+                    Err(err) => {
+                        eprintln!("{}", err);
+                        None
                     }
-                    Err(_) => match Url::parse(args[1]) {
-                        Ok(url) => {
-                            country_index = 0;
-                            url
-                        }
-                        Err(_) => {
-                            eprintln!("skipping input line: bad url {}", args.join("\t"));
-                            return Err("bad url");
-                        }
-                    },
-                };
-                let country = Country::from_str(args[country_index]);
-                if let None = country {
-                    eprintln!(
-                        "unknown country -> {}; considering as None",
-                        args[country_index]
-                    );
-                }
-                Ok((url, country))
-            }
-            _ => {
-                eprintln!("skipping bad input line: {}", args.join("\t"));
-                return Err("bad input line");
-            }
-        }
+                },
+            )
+            .filter(|mirror| config.is_protocol_allowed_for_url(&mirror.url))
+            .collect();
+        tx_progress
+            .send(format!("READ {} MIRRORS FROM STDIN", mirrors.len()))
+            .unwrap();
+        Ok(mirrors)
     }
-}
-
-pub fn read_mirrors(
-    config: Arc<Config>,
-    target: StdinTarget,
-    tx_progress: mpsc::Sender<String>,
-) -> Vec<Mirror> {
-    let fallback_protocols;
-    let allowed_protocols: &[Protocol] = match config.protocols.len() {
-        0 => {
-            fallback_protocols = vec![Protocol::Http, Protocol::Https];
-            &fallback_protocols
-        }
-        _ => &config.protocols,
-    };
-    let mirrors: Vec<Mirror> = io::stdin()
-        .lock()
-        .lines()
-        .filter_map(|line| Mirror::line_to_mirror_info(line.unwrap()).ok())
-        .filter_map(|(url, country)| {
-            Some(Mirror {
-                country,
-                output: format!(
-                    "{}{}",
-                    target.output_prefix,
-                    url.join(&target.path_to_return)
-                        .expect("failed to join path-to-return")
-                        .as_str()
-                        .to_owned()
-                ),
-                url_to_test: url
-                    .join(&target.path_to_test)
-                    .expect("failed to join path-to-test"),
-                url,
-            })
-        })
-        .filter(|mirror| {
-            allowed_protocols.contains(&Protocol::from_str(mirror.url.scheme()).unwrap())
-        })
-        .collect();
-    tx_progress
-        .send(format!("READ {} MIRRORS FROM STDIN", mirrors.len()))
-        .unwrap();
-    mirrors
 }

--- a/src/targets/stdin.rs
+++ b/src/targets/stdin.rs
@@ -33,7 +33,7 @@ impl FetchMirrors for StdinTarget {
             .lock()
             .lines()
             .filter_map(
-                |line| match MirrorInfo::parse(&line.unwrap(), &self.separator) {
+                |line| match MirrorInfo::parse(&line.unwrap(), &self.input_separator) {
                     Ok(info) => Some(Mirror {
                         country: info.country,
                         url_to_test: info

--- a/src/targets/ubuntu.rs
+++ b/src/targets/ubuntu.rs
@@ -66,7 +66,7 @@ impl FetchMirrors for UbuntuTarget {
     fn fetch_mirrors(
         &self,
         config: Arc<Config>,
-        tx_progress: mpsc::Sender<String>,
+        _tx_progress: mpsc::Sender<String>,
     ) -> Result<Vec<Mirror>, AppError> {
         let url = "https://launchpad.net/ubuntu/+archivemirrors";
 
@@ -89,7 +89,7 @@ impl FetchMirrors for UbuntuTarget {
             .next()
             .ok_or(AppError::ParseError("mirror list table".to_string()))?;
 
-        let result: Vec<_> = table
+        let result = table
             .find(Name("tr").and(Class("head")))
             .flat_map(|head| -> Result<_, AppError> {
                 // the next <n> rows belongs to <country>
@@ -129,10 +129,6 @@ impl FetchMirrors for UbuntuTarget {
             })
             .flatten()
             .collect();
-
-        tx_progress
-            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
-            .unwrap();
 
         Ok(result)
     }

--- a/src/targets/ubuntu.rs
+++ b/src/targets/ubuntu.rs
@@ -1,0 +1,162 @@
+use crate::config::{AppError, Config, FetchMirrors};
+use crate::countries::Country;
+use crate::mirror::Mirror;
+use crate::target_configs::ubuntu::UbuntuTarget;
+use itertools::Itertools;
+use reqwest;
+use select::document::Document;
+use select::node::{Data, Node};
+use select::predicate::{Attr, Class, Name, Predicate};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use url::Url;
+
+#[derive(Debug)]
+struct UbuntuMirrorInfo {
+    urls: Vec<Url>,
+    is_up_to_date: bool,
+}
+
+fn parse_header(node: &Node) -> Result<(String, usize), AppError> {
+    let columns: Vec<_> = node.find(Name("th")).collect();
+    let country = columns
+        .first()
+        .ok_or(AppError::ParseError("country".to_string()))?
+        .text();
+
+    let n = columns
+        .last()
+        .ok_or(AppError::ParseError("number of mirrors".to_string()))?
+        .first_child()
+        .ok_or(AppError::ParseError("number of mirrors".to_string()))?
+        .text()
+        .trim()
+        .parse()
+        .map_err(|_e| AppError::ParseError("number of mirrors".to_string()))?;
+
+    Ok((country, n))
+}
+
+fn parse_mirror_info(node: &Node) -> Result<UbuntuMirrorInfo, AppError> {
+    let columns: Vec<_> = node.find(Name("td")).collect();
+
+    let urls = columns
+        .get(1)
+        .ok_or(AppError::ParseError("mirror row".to_string()))?
+        .find(Name("a"))
+        .filter_map(|x| x.attr("href"))
+        .filter_map(|x| x.parse().ok())
+        .collect();
+
+    let state = columns
+        .last()
+        .ok_or(AppError::ParseError("mirror state column".to_string()))?
+        .text()
+        .trim()
+        .to_lowercase();
+
+    Ok(UbuntuMirrorInfo {
+        urls,
+        is_up_to_date: state == "up to date",
+    })
+}
+
+fn display_mirror(target: &UbuntuTarget, url: &Url) -> String {
+    // The format for two one-line-style entries using the deb and deb-src types is:
+    //   type [ option1=value1 option2=value2 ] uri suite [component1] [component2] [...]
+    //
+    //   deb [ arch=amd64,armel ] http://us.archive.ubuntu.com/ubuntu trusty main restricted
+
+    let ref options = if target.options.len() > 0 {
+        format!(" [{}] ", target.options.join(" "))
+    } else {
+        " ".to_string()
+    };
+
+    let ref components = target.components.join(" ");
+
+    target
+        .types
+        .iter()
+        .flat_map(|type_| {
+            target
+                .suites
+                .iter()
+                .map(move |suite| format!("{}{}{} {} {}", type_, options, url, suite, components))
+        })
+        .join("\n")
+}
+
+impl FetchMirrors for UbuntuTarget {
+    fn fetch_mirrors(
+        &self,
+        config: Arc<Config>,
+        tx_progress: mpsc::Sender<String>,
+    ) -> Result<Vec<Mirror>, AppError> {
+        let url = "https://launchpad.net/ubuntu/+archivemirrors";
+
+        let output = Runtime::new().unwrap().block_on(async {
+            Ok::<_, AppError>(
+                reqwest::Client::new()
+                    .get(url)
+                    .timeout(Duration::from_millis(self.fetch_mirrors_timeout))
+                    .send()
+                    .await?
+                    .text_with_charset("utf-8")
+                    .await?,
+            )
+        })?;
+
+        let document = Document::from(output.as_str());
+
+        let table = document.find(Attr("id", "mirrors_list")).next().unwrap();
+
+        let result: Vec<_> = table
+            .find(Name("tr").and(Class("head")))
+            .flat_map(|head| -> Result<_, AppError> {
+                // the next <n> rows belongs to <country>
+                let (country, n) = parse_header(&head)?;
+
+                let mut mirrors = Vec::with_capacity(n);
+                let mut current = head;
+
+                loop {
+                    current = match current.next() {
+                        None => break,
+                        Some(node) => node,
+                    };
+
+                    if matches!(current.data(), Data::Element(_, _)) {
+                        mirrors.push(parse_mirror_info(&current)?);
+                    }
+                    if mirrors.len() == n || current.is(Class("section-break")) {
+                        break;
+                    }
+                }
+
+                Ok(mirrors
+                    .into_iter()
+                    .filter(|m| m.is_up_to_date)
+                    .filter_map(|m| {
+                        let url = config.get_preferred_url(&m.urls)?;
+
+                        Some(Mirror {
+                            country: Country::from_str(&country),
+                            output: display_mirror(self, url),
+                            url: url.clone(),
+                            url_to_test: url.join(&self.path_to_test).unwrap(),
+                        })
+                    })
+                    .collect::<Vec<_>>())
+            })
+            .flatten()
+            .collect();
+
+        tx_progress
+            .send(format!("MIRRORS LEFT AFTER FILTERING: {}", result.len()))
+            .unwrap();
+
+        Ok(result)
+    }
+}


### PR DESCRIPTION
Introduced traits for targets that describe the behavior for retrieving a list of mirrors and displaying them. This allows you to get rid of `match` expressions for each target. To add a new target, you just need to implement these two traits.