### PR TITLE
consistent formatting of SpeedTestResult Display

### DIFF
--- a/src/speed_test.rs
+++ b/src/speed_test.rs
@@ -73,7 +73,7 @@ impl fmt::Display for SpeedTestResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "SpeedTestResult {{ speed: {}; elapsed: {:?}; connection_time: {:?}}}",
+            "SpeedTestResult {{ speed: {}; elapsed: {:?}; connection_time: {:?} }}",
             self.fmt_speed(),
             self.elapsed,
             self.connection_time,


### PR DESCRIPTION
fix the formatting of SpeedTestResult to have the curly brace at the
start/end have a space after/before the curly brace, respectively.

This has been bugging me a lot, so I thought I'd open this simple PR.
If this is not wanted for some reason, feel free to just deny the PR :)