### PR TITLE
new config to disable file comments only

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -212,6 +212,10 @@ pub struct Config {
     /// Disable printing comments
     #[structopt(long = "disable-comments")]
     pub disable_comments: bool,
+
+    /// Disable printing comments to output file
+    #[structopt(long = "disable-file-comments")]
+    pub disable_file_comments: bool,
 }
 
 impl Config {


### PR DESCRIPTION
--disable-comments flag makes it seem like the script froze (and I like seeing what the script does), but writing them makes the mirrorlist file way too long. So I added a new flag that prints the comments without writing them to the file. It is not the cleanest solution, so feel free to make changes/suggestions or reject the PR :)