### PR TITLE
README.md: Replace --save with --save-to-file in usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Each subcommand has its own options, so run `rate-mirrors arch --help` to see
    ```
    export TMPFILE="$(mktemp)"; \
        sudo true; \
-       rate-mirrors --save=$TMPFILE arch --max-delay=43200 \
+       rate-mirrors --save-to-file=$TMPFILE arch --max-delay=43200 \
          && sudo mv /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist-backup \
          && sudo mv $TMPFILE /etc/pacman.d/mirrorlist
    ```
@@ -136,7 +136,7 @@ The tool uses the following info:
 alias ua-drop-caches='sudo paccache -rk3; yay -Sc --aur --noconfirm'
 alias ua-update-all='export TMPFILE="$(mktemp)"; \
     sudo true; \
-    rate-mirrors --save=$TMPFILE arch --max-delay=21600 \
+    rate-mirrors --save-to-file=$TMPFILE arch --max-delay=21600 \
       && sudo mv /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist-backup \
       && sudo mv $TMPFILE /etc/pacman.d/mirrorlist \
       && ua-drop-caches \


### PR DESCRIPTION
The --save CLI option was replaced by --save-to-file with the 0.16 release.

Addresses issue https://github.com/westandskif/rate-mirrors/issues/46