### PR TITLE
Update artix mirrorlist URL

### DIFF
--- a/src/targets/artix.rs
+++ b/src/targets/artix.rs
@@ -24,7 +24,8 @@ impl FetchMirrors for ArtixTarget {
         config: Arc<Config>,
         _tx_progress: mpsc::Sender<String>,
     ) -> Result<Vec<Mirror>, AppError> {
-        let url = "https://gitea.artixlinux.org/packages/artix-mirrorlist/raw/branch/master/trunk/mirrorlist";
+        let url =
+            "https://gitea.artixlinux.org/packages/artix-mirrorlist/raw/branch/master/mirrorlist";
 
         let output = Runtime::new().unwrap().block_on(async {
             Ok::<_, AppError>(


### PR DESCRIPTION
Very similar to #42. Seems like they have changed it again

Old url (now 404): https://gitea.artixlinux.org/packages/artix-mirrorlist/raw/branch/master/trunk/mirrorlist
New url: https://gitea.artixlinux.org/packages/artix-mirrorlist/raw/branch/master/mirrorlist