### PR TITLE
switched Manjaro to mirror-manager urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.17.0 (XXXX-XX-XX)
+
+- switched Manjaro to use https://mirror-manager.manjaro.org/status.json
+  instead of https://repo.manjaro.org/status.json
+- started to return non-zero code when there are no mirrors left after
+  pre-filtering
+
 # 0.16.4 (2023-07-28)
 
 - changed rebornos mirrorlist url[#49 by SoulHarsh007](https://github.com/westandskif/rate-mirrors/pull/49)

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,8 @@ pub enum AppError {
     Root,
     #[error("failed to connect to {0}, consider increasing fetch-mirrors-timeout")]
     RequestTimeout(String),
+    #[error("no mirrors after filtering")]
+    NoMirrorsAfterFiltering,
     #[error("{0}")]
     RequestError(String),
     #[error(transparent)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,8 +128,13 @@ fn main() -> Result<(), AppError> {
     let results: Vec<_> = rx_results.iter().flatten().collect();
 
     if results.is_empty() {
+        let untested_mirrors: Vec<Mirror> = rx_mirrors.into_iter().collect();
+        if untested_mirrors.len() == 0 {
+            output.display_comment("==== NO MIRRORS AFTER FILTERING ====");
+            return Err(AppError::NoMirrorsAfterFiltering);
+        }
         output.display_comment("==== FAILED TO TEST SPEEDS, RETURNING UNTESTED MIRRORS ====");
-        for mirror in rx_mirrors.into_iter() {
+        for mirror in untested_mirrors.into_iter() {
             output.display_mirror(&mirror);
         }
     } else {

--- a/src/target_configs/manjaro.rs
+++ b/src/target_configs/manjaro.rs
@@ -6,6 +6,9 @@ pub enum ManjaroBranch {
     Stable,
     Testing,
     Unstable,
+    ARMStable,
+    ARMTesting,
+    ARMUnstable,
 }
 impl FromStr for ManjaroBranch {
     type Err = &'static str;
@@ -14,6 +17,9 @@ impl FromStr for ManjaroBranch {
             "stable" => Ok(ManjaroBranch::Stable),
             "testing" => Ok(ManjaroBranch::Testing),
             "unstable" => Ok(ManjaroBranch::Unstable),
+            "arm_stable" => Ok(ManjaroBranch::ARMStable),
+            "arm_testing" => Ok(ManjaroBranch::ARMTesting),
+            "arm_unstable" => Ok(ManjaroBranch::ARMUnstable),
             _ => Err("could not parse branch"),
         }
     }
@@ -25,6 +31,9 @@ impl fmt::Display for ManjaroBranch {
             ManjaroBranch::Stable => "stable",
             ManjaroBranch::Testing => "testing",
             ManjaroBranch::Unstable => "unstable",
+            ManjaroBranch::ARMStable => "arm_stable",
+            ManjaroBranch::ARMTesting => "arm_testing",
+            ManjaroBranch::ARMUnstable => "arm_unstable",
         };
         write!(f, "{}", repr)
     }


### PR DESCRIPTION
- switched Manjaro to use https://mirror-manager.manjaro.org/status.json
  instead of https://repo.manjaro.org/status.json
- started to return non-zero code when there are no mirrors left after
  pre-filtering

related: #51 