### PR TITLE
Feat: Add top_mirrors_number_to_save CLI arg

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -256,6 +256,14 @@ pub struct Config {
     /// Disable printing comments to output file
     #[arg(env = "RATE_MIRRORS_DISABLE_COMMENTS_IN_FILE", long)]
     pub disable_comments_in_file: bool,
+
+    /// Number of top mirrors to save to output file. Default 100.
+    #[arg(
+        env = "RATE_MIRRORS_TOP_MIRRORS_NUMBER_TO_SAVE",
+        long,
+        default_value = "100"
+    )]
+    pub top_mirrors_number_to_save: usize,
 }
 
 impl Config {


### PR DESCRIPTION
Summary
----

This adds the following CLI flag: `top_mirrors_number_to_save`. By default this value is set to 100.

This basically allows users to do:

```
$ rate-mirrors --disable-comments-in-file --save top5.txt --top-mirrors-number-to-save 5 artix
```

This would produce the following output for top5.txt:

```
server1
server2
server3
server4
server5
```