### PR TITLE
Fix RebornOS org name in the URL for the raw mirrorlist file

### DIFF
--- a/src/targets/rebornos.rs
+++ b/src/targets/rebornos.rs
@@ -24,7 +24,7 @@ impl FetchMirrors for RebornOSTarget {
         config: Arc<Config>,
         _tx_progress: mpsc::Sender<String>,
     ) -> Result<Vec<Mirror>, AppError> {
-        let url = "https://raw.githubusercontent.com/RebornOS-Developers/rebornos-mirrorlist/main/reborn-mirrorlist";
+        let url = "https://raw.githubusercontent.com/RebornOS-Team/rebornos-mirrorlist/main/reborn-mirrorlist";
 
         let mirrorlist_file_text = Runtime::new().unwrap().block_on(async {
             Ok::<_, AppError>(


### PR DESCRIPTION
Our GitHub organization changed its name from `rebornos-developers` to `rebornos-team`. But GitHub's redirects kept the old URL alive. The old URL no longer works because the redirects have stopped. Hence we have to fix the URL of the raw mirrorlist file as soon as possible.