### PR TITLE
Add systemd service and timer

### DIFF
--- a/rate-mirrors.service
+++ b/rate-mirrors.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Rate pacman mirrors and update mirrorlist
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+StandardOutput=null
+ProtectSystem=strict
+ReadWritePaths=-/etc/pacman.d
+Environment=RATE_MIRRORS_ALLOW_ROOT=true
+ExecStart=/bin/sh -c 'rate-mirrors --country-neighbors-per-country=2 --country-test-mirrors-per-country=10 --max-jumps=2 --top-mirrors-number-to-retest=10 arch --completion=1 --max-delay=21600 --sort-mirrors-by=score_asc | tee /etc/pacman.d/mirrorlist'
+
+[Install]
+WantedBy=multi-user.target

--- a/rate-mirrors.timer
+++ b/rate-mirrors.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run rate-mirrors
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+RandomizedDelaySec=3h
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This is a default arch linux systemd service and timer to run rate-mirrors weekly. Please review and see if you want to include it in the main branch.