### PR TITLE
speed_test: Fix hang after re-testing top mirrors caused by tokio

### DIFF
--- a/src/speed_test.rs
+++ b/src/speed_test.rs
@@ -616,4 +616,11 @@ pub fn test_speed_by_countries(
     top_mirror_results.sort_by(|a, b| b.speed.partial_cmp(&a.speed).unwrap());
     top_mirror_results.append(&mut other_results);
     tx_results.send(top_mirror_results).unwrap();
+
+    // Drop channels before shutting down the runtime. Without this, if the
+    // runtime drop blocks (e.g. reqwest connection-pool cleanup), tx_progress
+    // stays alive and the main thread hangs on rx_progress.into_iter().
+    drop(tx_progress);
+    drop(tx_results);
+    runtime.shutdown_timeout(Duration::from_secs(1));
 }


### PR DESCRIPTION
On CachyOS we noticed that the mirror ranking got way longer. After retesting top mirrors the thread is stucked and does not go further.