### PR TITLE
fix chaotic-aur commented server line

### DIFF
--- a/src/targets/chaotic.rs
+++ b/src/targets/chaotic.rs
@@ -30,8 +30,8 @@ impl FetchMirrors for ChaoticTarget {
         let urls = output
             .lines()
             .filter_map(|line| {
-                if line.starts_with("# Server = ") {
-                    Some(line.replace("# Server = ", ""))
+                if line.starts_with("#Server = ") {
+                    Some(line.replace("#Server = ", ""))
                 } else if line.starts_with("Server = ") {
                     Some(line.replace("Server = ", ""))
                 } else {


### PR DESCRIPTION
Apparently they changed their formatting.
With the fix, it can finally parse all the mirrors from the file again.

Maybe we should add both variants, with and without the space after the '#'