### PR TITLE
cachyos: use mirrorlist API

### DIFF
--- a/src/target_configs/cachyos.rs
+++ b/src/target_configs/cachyos.rs
@@ -10,14 +10,26 @@ pub struct CachyOSTarget {
     )]
     pub fetch_mirrors_timeout: u64,
 
-    /// Either url or path to CachyOS mirror list file
+    /// Either url or path to a CachyOS mirror source.
+    ///   Accepts the dashboard JSON API response or a plain pacman
+    ///   mirrorlist file.
     #[arg(
         env = "RATE_MIRRORS_MIRROR_LIST_FILE",
         long,
-        default_value = "https://raw.githubusercontent.com/CachyOS/CachyOS-PKGBUILDS/master/cachyos-mirrorlist/cachyos-mirrorlist",
+        default_value = "https://cachyos.org/archlinuxmirrorlist/api/cachyos-mirrors",
         verbatim_doc_comment
     )]
     pub mirror_list_file: String,
+
+    /// Max acceptable delay in seconds since the mirror was last synced
+    ///   (only applied to the JSON API source, which reports per-mirror)
+    #[arg(
+        env = "RATE_MIRRORS_MAX_DELAY",
+        long,
+        default_value = "86400",
+        verbatim_doc_comment
+    )]
+    pub max_delay: i64,
 
     /// Path to be joined to a mirror url and used for speed testing
     ///   the file should be big enough to allow for testing high

--- a/src/targets/cachyos.rs
+++ b/src/targets/cachyos.rs
@@ -2,25 +2,39 @@ use crate::config::{AppError, FetchMirrors, LogFormatter, fetch_text_or_file};
 use crate::countries::Country;
 use crate::mirror::Mirror;
 use crate::target_configs::cachyos::CachyOSTarget;
+use serde::Deserialize;
 use std::fmt::Display;
 use std::sync::mpsc;
 use url::Url;
 
-/// Parse the `code=XX` country boundary from CachyOS metadata comments like:
-///   `## tier=1 code=US`
-///   `## tier=2 code=RU`
-/// Outer None: no `code=` token on the line (not a boundary). Inner None:
-/// GLOBAL / unknown codes — a boundary that leaves Server lines unlabeled.
-fn parse_country_code_from_line(line: &str) -> Option<Option<&'static Country>> {
-    let code = line
-        .split_whitespace()
-        .find_map(|token| token.strip_prefix("code="))?;
-    // ISO 3166-1 alpha-2 only; pseudo-codes like GLOBAL resolve to unlabeled
-    if code.len() == 2 && code.bytes().all(|b| b.is_ascii_alphabetic()) {
-        Some(Country::from_str(code))
+/// A single entry of the CachyOS dashboard mirrors API.
+#[derive(Deserialize, Debug, Clone)]
+struct CachyMirror {
+    country_code: String,
+    url: String,
+    delay_seconds: Option<i64>,
+}
+
+#[derive(Deserialize, Debug)]
+struct CachyMirrorsData {
+    mirrors: Vec<CachyMirror>,
+}
+
+/// Resolve a raw upstream country code to a `Country`.
+/// `GLOBAL` (case-insensitive, worldwide CDN) and unknown codes map to `None`.
+fn resolve_country(code: &str) -> Option<&'static Country> {
+    if code.eq_ignore_ascii_case("GLOBAL") {
+        None
     } else {
-        Some(None)
+        Country::from_str(code)
     }
+}
+
+/// Extract the `code=XX` token from a CachyOS metadata comment.
+/// Returns `None` when the line carries no `code=` token.
+fn country_code_from_line(line: &str) -> Option<&str> {
+    line.split_whitespace()
+        .find_map(|token| token.strip_prefix("code="))
 }
 
 impl LogFormatter for CachyOSTarget {
@@ -39,27 +53,45 @@ impl LogFormatter for CachyOSTarget {
     }
 }
 
-impl FetchMirrors for CachyOSTarget {
-    fn fetch_mirrors(&self, tx_progress: mpsc::Sender<String>) -> Result<Vec<Mirror>, AppError> {
-        let output = fetch_text_or_file(&self.mirror_list_file, self.fetch_mirrors_timeout)?;
+impl CachyOSTarget {
+    /// Parse the dashboard JSON API response.
+    fn parse_api_json(&self, raw: &str) -> Option<Vec<Mirror>> {
+        let data: CachyMirrorsData = serde_json::from_str(raw).ok()?;
 
-        let mut current_country = None;
+        let result = data
+            .mirrors
+            .into_iter()
+            // Apply the sync-delay threshold only when the source reports a
+            // delay.
+            .filter(|m| m.delay_seconds.is_none_or(|delay| delay <= self.max_delay))
+            .filter_map(|m| {
+                let url = Url::parse(&m.url).ok()?;
+                let url_to_test = url.join(&self.path_to_test).ok()?;
+                Some(Mirror {
+                    country: resolve_country(&m.country_code),
+                    url,
+                    url_to_test,
+                })
+            })
+            .collect();
+
+        Some(result)
+    }
+
+    /// Parse a plain pacman mirrorlist.
+    fn parse_mirrorlist(&self, raw: &str) -> Vec<Mirror> {
+        let mut current_country: Option<&'static Country> = None;
         let mut mirrors = Vec::new();
 
-        for line in output.lines() {
+        for line in raw.lines() {
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 continue;
             }
 
-            // Metadata comments carry country: `## tier=2 code=US`
             if trimmed.starts_with('#') {
-                // Any code= token is a country boundary; GLOBAL and unknown
-                // codes reset to unlabeled. Other comments (attribution,
-                // disabled servers) leave country sticky until the next
-                // code= line — matches how CachyOS groups Server lines.
-                if let Some(country) = parse_country_code_from_line(trimmed) {
-                    current_country = country;
+                if let Some(code) = country_code_from_line(trimmed) {
+                    current_country = resolve_country(code);
                 }
                 continue;
             }
@@ -69,29 +101,35 @@ impl FetchMirrors for CachyOSTarget {
             };
             let cleaned = rest.replace("$arch/$repo", "");
 
-            match Url::parse(&cleaned) {
-                Ok(url) => {
-                    let url_to_test = url
-                        .join(&self.path_to_test)
-                        .expect("failed to join path_to_test");
+            if let Ok(url) = Url::parse(&cleaned) {
+                if let Ok(url_to_test) = url.join(&self.path_to_test) {
                     mirrors.push(Mirror {
                         country: current_country,
                         url,
                         url_to_test,
                     });
                 }
-                Err(e) => {
-                    tx_progress
-                        .send(format!(
-                            "cachyos: skipping unparseable URL {}: {}",
-                            cleaned, e
-                        ))
-                        .ok();
-                }
             }
         }
 
-        Ok(mirrors)
+        mirrors
+    }
+}
+
+impl FetchMirrors for CachyOSTarget {
+    fn fetch_mirrors(&self, tx_progress: mpsc::Sender<String>) -> Result<Vec<Mirror>, AppError> {
+        let output = fetch_text_or_file(&self.mirror_list_file, self.fetch_mirrors_timeout)?;
+
+        let result = match self.parse_api_json(&output) {
+            Some(mirrors) => mirrors,
+            None => self.parse_mirrorlist(&output),
+        };
+
+        tx_progress
+            .send(format!("FETCHED MIRRORS: {}", result.len()))
+            .unwrap();
+
+        Ok(result)
     }
 }
 
@@ -99,43 +137,115 @@ impl FetchMirrors for CachyOSTarget {
 mod tests {
     use super::*;
 
+    fn make_target(max_delay: i64) -> CachyOSTarget {
+        CachyOSTarget {
+            fetch_mirrors_timeout: 15000,
+            mirror_list_file: String::new(),
+            path_to_test: "x86_64/cachyos/cachyos.files".to_string(),
+            arch: "auto".to_string(),
+            comment_prefix: "# ".to_string(),
+            max_delay,
+        }
+    }
+
     #[test]
-    fn parses_iso_country_codes() {
+    fn country_code_from_line_extracts_token() {
+        assert_eq!(country_code_from_line("## tier=1 code=US"), Some("US"));
+        assert_eq!(country_code_from_line("## tier=2 code=RU"), Some("RU"));
+        assert_eq!(country_code_from_line("## tier=1 code=AT"), Some("AT"));
         assert_eq!(
-            parse_country_code_from_line("## tier=1 code=US")
-                .flatten()
-                .map(|c| c.code),
-            Some("US")
-        );
-        assert_eq!(
-            parse_country_code_from_line("## tier=2 code=RU")
-                .flatten()
-                .map(|c| c.code),
-            Some("RU")
-        );
-        assert_eq!(
-            parse_country_code_from_line("## tier=1 code=AT")
-                .flatten()
-                .map(|c| c.code),
-            Some("AT")
+            country_code_from_line("## tier=1 code=GLOBAL"),
+            Some("GLOBAL")
         );
     }
 
     #[test]
-    fn global_and_unknown_codes_are_unlabeled_boundaries() {
-        assert!(matches!(
-            parse_country_code_from_line("## tier=1 code=GLOBAL"),
-            Some(None)
-        ));
-        assert!(matches!(
-            parse_country_code_from_line("## tier=2 code=ZZ"),
-            Some(None)
-        ));
+    fn country_code_from_line_returns_none_for_non_code_lines() {
+        assert!(country_code_from_line("## USA Mirror much thanks to Soulharsh!").is_none());
+        assert!(country_code_from_line("Server = https://example/").is_none());
     }
 
     #[test]
-    fn non_code_lines_are_not_boundaries() {
-        assert!(parse_country_code_from_line("## USA Mirror much thanks to Soulharsh!").is_none());
-        assert!(parse_country_code_from_line("Server = https://example/").is_none());
+    fn resolve_country_handles_known_global_and_unknown() {
+        assert_eq!(resolve_country("US").map(|c| c.code), Some("US"));
+        assert_eq!(resolve_country("DE").map(|c| c.code), Some("DE"));
+        assert!(resolve_country("GLOBAL").is_none());
+        assert!(resolve_country("ABCD").is_none());
+    }
+
+    #[test]
+    fn parses_api_json_with_country_and_delay_filter() {
+        let target = make_target(86400);
+        let raw = r#"{
+            "mirrors": [
+                {"country_code": "DE", "url": "https://de.example.org/repo/", "delay_seconds": 0},
+                {"country_code": "GLOBAL", "url": "https://cdn.example.org/repo/", "delay_seconds": 10},
+                {"country_code": "FR", "url": "https://fr.example.org/repo/", "delay_seconds": 999999},
+                {"country_code": "US", "url": "https://us.example.org/repo/", "delay_seconds": null}
+            ]
+        }"#;
+
+        let mirrors = target.parse_api_json(raw).expect("valid API json");
+
+        assert_eq!(mirrors.len(), 3);
+        assert!(
+            mirrors
+                .iter()
+                .all(|m| m.url.as_str() != "https://fr.example.org/repo/")
+        );
+
+        let de = mirrors
+            .iter()
+            .find(|m| m.url.as_str() == "https://de.example.org/repo/")
+            .expect("DE mirror kept");
+        assert_eq!(de.country.map(|c| c.code), Some("DE"));
+        assert_eq!(
+            de.url_to_test.as_str(),
+            "https://de.example.org/repo/x86_64/cachyos/cachyos.files"
+        );
+
+        // global unlabeled
+        let global = mirrors
+            .iter()
+            .find(|m| m.url.as_str() == "https://cdn.example.org/repo/")
+            .expect("GLOBAL mirror kept");
+        assert!(global.country.is_none());
+    }
+
+    #[test]
+    fn falls_back_to_plain_mirrorlist_with_sticky_country() {
+        let target = make_target(86400);
+        let raw = "\
+## Some comment
+## tier=1 code=DE
+Server = https://de.example.org/repo/$arch/$repo
+# Server = https://commented.example.org/repo/$arch/$repo
+Server = https://fr.example.org/repo/$arch/$repo
+";
+
+        assert!(target.parse_api_json(raw).is_none());
+
+        let mirrors = target.parse_mirrorlist(raw);
+        assert_eq!(mirrors.len(), 2);
+        assert_eq!(mirrors[0].url.as_str(), "https://de.example.org/repo/");
+        assert_eq!(mirrors[0].country.map(|c| c.code), Some("DE"));
+        assert_eq!(mirrors[1].url.as_str(), "https://fr.example.org/repo/");
+        assert_eq!(mirrors[1].country.map(|c| c.code), Some("DE"));
+    }
+
+    #[test]
+    fn mirrorlist_resets_country_on_global_code() {
+        let target = make_target(86400);
+        let raw = "\
+## tier=1 code=DE
+Server = https://de.example.org/repo/$arch/$repo
+## tier=1 code=GLOBAL
+Server = https://cdn.example.org/repo/$arch/$repo
+";
+
+        let mirrors = target.parse_mirrorlist(raw);
+        assert_eq!(mirrors.len(), 2);
+        assert_eq!(mirrors[0].country.map(|c| c.code), Some("DE"));
+        assert!(mirrors[1].country.is_none());
     }
 }


### PR DESCRIPTION
provides additional metadata (similarly to archlinux mirrorlist API), rather than relaying only on the speed and latency of the mirrors.

while refactoring existing mirrorlist code parsing..